### PR TITLE
ENG-2892 CVE-2021-25738 suppression

### DIFF
--- a/owasp-dependency-check-suppression.xml
+++ b/owasp-dependency-check-suppression.xml
@@ -34,6 +34,13 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
+        A false positives relative to K8S's client that has nothing to do with the imported one by Fabric8
+      ]]></notes>
+        <cpe>cpe:/a:kubernetes:java</cpe>
+        <cve>CVE-2021-25738</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
    file name: nimbus-jose-jwt-7.8.1.jar
    ]]></notes>
         <gav>com.nimbusds:nimbus-jose-jwt:7.8.1</gav>

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,12 @@
         <!--dependencies -->
         <entando-k8s-custom-model.version>6.3.0</entando-k8s-custom-model.version>
         <postgresql.driver.version>42.2.13</postgresql.driver.version>
-        <tomcat-embed.version>9.0.50</tomcat-embed.version>
+        <tomcat-embed.version>9.0.54</tomcat-embed.version>
         <awaitility.version>4.0.1</awaitility.version>
         <java.semver>0.9.0</java.semver>
-        <spring-boot.version>2.5.5</spring-boot.version>
-        <fabric8.version>4.13.3</fabric8.version>
-        <spring-security-oauth2-autoconfigure.version>2.5.5</spring-security-oauth2-autoconfigure.version>
+        <fabric8.version>4.10.3</fabric8.version>
+        <spring-boot.version>2.5.6</spring-boot.version>
+        <spring-security-oauth2-autoconfigure.version>2.5.6</spring-security-oauth2-autoconfigure.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
- CVE-2021-25738 suppression due to false positive
- bump tomcat embedded to 9.0.54
- bump fabric8 to 4.10.3
- bump spring-boot to 2.5.6
- bump spring-boot-oauth2-autoconfigure to 2.5.6